### PR TITLE
Force PIN brute forcing on systems with broken TPMs

### DIFF
--- a/src/usr/lib/sectpmctl/scripts/sectpmctl-tpm
+++ b/src/usr/lib/sectpmctl/scripts/sectpmctl-tpm
@@ -26,11 +26,12 @@ function rand8str()
   echo "${xored}"
 }
 
-
 function rand8file()
 {
   local n8="${1}"
   local file="${2}"
+  
+  rm "${file}" 2> /dev/null > /dev/null || true
 
   local getrand=$(rand8str "${n8}")
 
@@ -659,7 +660,8 @@ echo -n "Enter TPM or LUKS Password: "
 read -sr password || true
 echo
 
-sectpmctl key unseal --handle "${PERSISTANT_HANDLE_TO_USE}" --password "\${password}" --pcr-extend 1>&3 3>&-
+pwdhashed="\$(sectpmctl hash --salt "${SECTPMCTL_KEYS}/pwd.salt" "\${password}")"
+sectpmctl key unseal --handle "${PERSISTANT_HANDLE_TO_USE}" --password-hex "0x\${pwdhashed}" --pcr-extend 1>&3 3>&-
 retValUnseal=\$?
 
 if [ \$retValUnseal -ne 0 ]; then
@@ -668,6 +670,8 @@ if [ \$retValUnseal -ne 0 ]; then
         echo -n "\${password}" 1>&3 3>&-
         exit 1
 fi
+
+echo -n "\${password}" 1>&3 3>&-
 
 sectpmctl key extend --random
 retValExtend=\$?
@@ -887,6 +891,7 @@ generate_tpm2_policy() {
   TEMPDIR="$(mktemp -d -p /tmp)"
   chmod 700 "${TEMPDIR}"
   TPM_SECRET_LUKS_KEY="tpmkey"
+  TPM_SECRET_FOR_LUKS_KEY="lukskey"
 
   mount -t tmpfs "${TEMPDIR##*/}" "${TEMPDIR}"
 
@@ -895,6 +900,14 @@ generate_tpm2_policy() {
 
   echo "CREATE SECRET TPM LUKS KEY"
   rand8file 16 "${TPM_SECRET_LUKS_KEY}"
+  cp "${TPM_SECRET_LUKS_KEY}" "${TPM_SECRET_FOR_LUKS_KEY}"
+  if [[ -n ${TPM_PASSWORD} ]]; then
+    echo -n "${TPM_PASSWORD}" >> "${TPM_SECRET_FOR_LUKS_KEY}"
+    echo "CREATE SALT FOR ARGON2"
+    rand8file 4 "${SECTPMCTL_KEYS}/pwd.salt"
+  else
+    rm "${SECTPMCTL_KEYS}/pwd.salt" 2> /dev/null > /dev/null
+  fi
 
   if [[ $( cryptsetup luksDump "${CRYPT_PARTITION}" | grep -c "${TPM_KEYSLOT}: luks2") != 0 ]]; then
     echo "KILL EXISTING TPM LUKS KEY FROM KEYSLOT"
@@ -918,14 +931,14 @@ generate_tpm2_policy() {
       --key-slot="${TPM_KEYSLOT}" \
       luksAddKey \
       "${CRYPT_PARTITION}" \
-      "${TPM_SECRET_LUKS_KEY}" || ( echo "COULD NOT ADD KEY" && exit 2 )
+      "${TPM_SECRET_FOR_LUKS_KEY}" || ( echo "COULD NOT ADD KEY" && exit 2 )
   else
     cryptsetup \
       --key-slot="${TPM_KEYSLOT}" \
       --key-file="${KEY_FILE}" \
       luksAddKey \
       "${CRYPT_PARTITION}" \
-      "${TPM_SECRET_LUKS_KEY}" || ( echo "COULD NOT ADD KEY" && exit 2 )
+      "${TPM_SECRET_FOR_LUKS_KEY}" || ( echo "COULD NOT ADD KEY" && exit 2 )
   fi
   
   echo "EXTEND PCR 11"
@@ -1012,12 +1025,14 @@ generate_tpm2_policy() {
     USE_PRESEED_PCR="--pcr-preseed"
   fi
   if [[ -n ${TPM_PASSWORD} ]]; then
-    sectpmctl key seal --handle "${PERSISTANT_HANDLE_TO_USE}" --key-file "${TPM_SECRET_LUKS_KEY}" --password "${TPM_PASSWORD}" --pcr-extend ${USE_PRESEED_PCR}
+    TPM_HASHED_PASSWORD="$(sectpmctl hash --salt "${SECTPMCTL_KEYS}/pwd.salt" "${TPM_PASSWORD}")"
+    sectpmctl key seal --handle "${PERSISTANT_HANDLE_TO_USE}" --key-file "${TPM_SECRET_LUKS_KEY}" --password-hex "0x${TPM_HASHED_PASSWORD}" --pcr-extend ${USE_PRESEED_PCR}
   else
     sectpmctl key seal --handle "${PERSISTANT_HANDLE_TO_USE}" --key-file "${TPM_SECRET_LUKS_KEY}" --noda --pcr-extend ${USE_PRESEED_PCR}
   fi
 
   shred -f -z -u "${TPM_SECRET_LUKS_KEY}"
+  shred -f -z -u "${TPM_SECRET_FOR_LUKS_KEY}"
   
   cd - > /dev/null
   umount "${TEMPDIR}"
@@ -1083,6 +1098,7 @@ copy_exec /bin/bash /bin
 
 copy_exec ${SECTPMCTL_KEYS}/tpm_owner.pub ${SECTPMCTL_KEYS}/tpm_owner.pub
 copy_exec ${SECTPMCTL_KEYS}/tpm_owner_noda.pub ${SECTPMCTL_KEYS}/tpm_owner_noda.pub
+copy_exec ${SECTPMCTL_KEYS}/pwd.salt ${SECTPMCTL_KEYS}/pwd.salt
 
 copy_exec /usr/bin/awk /usr/bin
 copy_exec /usr/bin/basename /usr/bin
@@ -1114,6 +1130,7 @@ copy_exec /usr/bin/wc /usr/bin
 
 copy_exec /usr/sbin/sectpmctl /usr/sbin
 
+copy_exec /usr/libexec/sectpmctl/sectpmctl-hash /usr/libexec/sectpmctl/sectpmctl-hash
 copy_exec /usr/lib/sectpmctl/scripts/sectpmctl-key /usr/lib/sectpmctl/scripts/sectpmctl-key
 copy_exec /usr/lib/x86_64-linux-gnu/libtss2-tcti-device.so.0 /usr/lib/x86_64-linux-gnu
 
@@ -1197,10 +1214,6 @@ initial_tpm2_setup() {
       "${CRYPTROOT_LABEL}"
   fi
 
-  add_tpm2_hook \
-    "${PCR_BANK}" \
-    "${SECTPMCTL_KEYS}"
-  
   edit_initramfs_conf
 
   edit_crypttab \
@@ -1227,6 +1240,10 @@ initial_tpm2_setup() {
       "${SECTPMCTL_KEYS}" \
       "${TPM_PASSWORD}"
   fi
+
+  add_tpm2_hook \
+    "${PCR_BANK}" \
+    "${SECTPMCTL_KEYS}"
 
   generate_unseal_script \
     "${PCR_BANK}" \

--- a/src/usr/libexec/sectpmctl/sectpmctl-hash.c
+++ b/src/usr/libexec/sectpmctl/sectpmctl-hash.c
@@ -1,0 +1,55 @@
+#include <argon2.h>
+
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+
+#include <unistd.h>
+
+int main(int argc, char **argv)
+{
+    // WORK IN PROGRESS
+
+    uint32_t hashlen = 32;
+    uint8_t hash[hashlen];
+
+    uint32_t saltlen = 32;
+    uint8_t salt[saltlen];
+    FILE *ptr;
+    ptr = fopen(argv[2],"rb");
+    fread(salt,saltlen,1,ptr); 
+    fclose(ptr);
+
+    uint32_t iterations = 4;
+    uint32_t memory = 1048576;
+    uint32_t threads = 4;
+
+    argon2_context context = {
+        hash,
+        hashlen,
+        argv[3],
+        strlen(argv[3]),
+        salt,
+        saltlen,
+        NULL, 0,
+        NULL, 0,
+        iterations, memory, threads, threads,
+        ARGON2_VERSION_13,
+        NULL, NULL,
+        ARGON2_DEFAULT_FLAGS
+    };
+
+    int rc = argon2id_ctx(&context);
+    if (rc != ARGON2_OK) {
+        fprintf(stderr, "error: %s\n", argon2_error_message(rc));
+        return 0
+    }
+
+    for (unsigned int i=0; i < hashlen; i++) {
+        printf("%02x", hash[i]);
+    }
+    printf( "\n" );
+    
+    return 0;
+}
+


### PR DESCRIPTION
The command line utility argon2 on Ubuntu 22.04 seems to be broken when parallelism is used. It only uses
as single thread. Interestingly the Ubuntu 22.04 libargon2 library doesn't suffer from this problem.